### PR TITLE
chore(create-webstone-app): treat the template as a workspace pkg to keep its dependencies in sync

### DIFF
--- a/.changeset/warm-dingos-glow.md
+++ b/.changeset/warm-dingos-glow.md
@@ -1,0 +1,6 @@
+---
+"webstone-app": patch
+"create-webstone-app": patch
+---
+
+Auto-update the template dependencies.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ To develop or contribute to Webstone, we use [Gitpod](https://www.gitpod.io). Cl
 
 Packages configured in `pnpm-workspace.yaml` are released automatically when a pull request is merged into the default branch, as long as there is at least one changeset present for a given package. Please refer to https://github.com/atlassian/changesets for details on changesets.
 
-To add a changeset, run `pnpm changeset` and commit the generated file as part of your pull request.
+To add a changeset:
+
+- Run `pnpm changeset`
+- Run `pnpm i` at the project root
+- Commit all files as part of your pull request
+
+When the PR gets merged, the [`.github/workflows/release.yml`](.github/workflows/release.yml) workflow will open a release pull request. Review & merge this to publish the changed packages to the NPM registry.
 
 ## The backstory of Webstone
 

--- a/packages/create-webstone-app/template/package.json
+++ b/packages/create-webstone-app/template/package.json
@@ -6,6 +6,6 @@
     "services/*"
   ],
   "devDependencies": {
-    "@webstone/core": "0.0.2"
+    "@webstone/core": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       fs-extra: 9.1.0
       prompts: 2.4.0
 
+  packages/create-webstone-app/template:
+    specifiers:
+      '@webstone/core': workspace:*
+    devDependencies:
+      '@webstone/core': link:../../core
+
 packages:
 
   /@babel/code-frame/7.12.13:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,2 @@
 packages:
   - "packages/**"
-  - "!packages/create-webstone-app/template"


### PR DESCRIPTION
Close #40.