### PR TITLE
Use Rollup for bundling

### DIFF
--- a/packages/create-webstone-app/package.json
+++ b/packages/create-webstone-app/package.json
@@ -5,10 +5,12 @@
   "author": "Mike Nikles, @mikenikles",
   "type": "module",
   "bin": "./bin.js",
+  "types": "./dist/create-webstone.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build:typescript": "tsc",
+    "build": "pnpm clean && pnpm build:typescript && rollup --config",
     "clean": "rm -fr ./dist",
-    "dev": "tsc --watch",
+    "dev": "concurrently \"tsc --watch\" \"rollup --config --watch\"",
     "prepublishOnly": "pnpm build",
     "prepare": "pnpm build",
     "test": "pnpm test:unit",
@@ -25,7 +27,11 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@rollup/plugin-typescript": "^8.3.3",
     "@types/node": "16.11.7",
+    "concurrently": "^7.2.2",
+    "rollup": "^2.77.0",
+    "rollup-plugin-dts": "^4.2.2",
     "typescript": "^4.7.4"
   },
   "dependencies": {

--- a/packages/create-webstone-app/rollup.config.js
+++ b/packages/create-webstone-app/rollup.config.js
@@ -1,0 +1,36 @@
+import typescript from "@rollup/plugin-typescript";
+import dts from "rollup-plugin-dts";
+import pkg from "./package.json";
+
+const external = [].concat(
+  Object.keys(pkg.dependencies || {}),
+  Object.keys(pkg.peerDependencies || {}),
+  Object.keys(process.binding("natives")),
+  "typescript"
+);
+
+/** @type {import('rollup').RollupOptions} */
+const config = [
+  {
+    input: "dist/compiled/index.js",
+    output: {
+      file: "dist/index.js",
+      format: "esm",
+      sourcemap: false,
+    },
+    external: (id) => {
+      return id.startsWith("node:") || external.includes(id);
+    },
+    plugins: [typescript()],
+  },
+  {
+    input: "dist/compiled/dts/index.d.ts",
+    output: {
+      file: "dist/create-webstone.d.ts",
+      format: "es",
+    },
+    plugins: [dts()],
+  },
+];
+
+export default config;

--- a/packages/create-webstone-app/src/index.ts
+++ b/packages/create-webstone-app/src/index.ts
@@ -1,5 +1,5 @@
-import { displayWelcome, displayNextSteps } from "./helpers.js";
-import { tasks } from "./tasks/index.js";
+import { displayWelcome, displayNextSteps } from "./helpers";
+import { tasks } from "./tasks/index";
 
 displayWelcome();
 const context = await tasks.run();

--- a/packages/create-webstone-app/src/tasks/2-prepare-project-structure/index.ts
+++ b/packages/create-webstone-app/src/tasks/2-prepare-project-structure/index.ts
@@ -8,7 +8,7 @@ import { Ctx } from "../../helpers";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export const copyTemplate = (ctx: Ctx) => {
-  const templateDir = path.join(__dirname, "../../..", "template");
+  const templateDir = path.join(__dirname, "..", "template");
   fs.copySync(templateDir, ctx.appDir);
 };
 

--- a/packages/create-webstone-app/tsconfig.json
+++ b/packages/create-webstone-app/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "outDir": "./dist",
+    "outDir": "./dist/compiled",
+    "declarationDir": "./dist/compiled/dts",
+    "isolatedModules": true,
+    "declaration": true,
     "target": "ESNext",
     "module": "ESNext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*"],
   "extends": "../../tsconfig.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,17 @@ importers:
 
   packages/create-webstone-app:
     specifiers:
+      '@rollup/plugin-typescript': ^8.3.3
       '@types/node': 16.11.7
       chalk: 5.0.1
+      concurrently: ^7.2.2
       create-svelte: 2.0.0-next.149
       enquirer: 2.3.6
       execa: 6.1.0
       fs-extra: 10.1.0
       listr2: 4.0.5
+      rollup: ^2.77.0
+      rollup-plugin-dts: ^4.2.2
       typescript: ^4.7.4
     dependencies:
       chalk: 5.0.1
@@ -77,7 +81,11 @@ importers:
       fs-extra: 10.1.0
       listr2: 4.0.5_enquirer@2.3.6
     devDependencies:
+      '@rollup/plugin-typescript': 8.3.3_55kiftncucr43pz4hskma6yi2q
       '@types/node': 16.11.7
+      concurrently: 7.2.2
+      rollup: 2.77.0
+      rollup-plugin-dts: 4.2.2_55kiftncucr43pz4hskma6yi2q
       typescript: 4.7.4
 
 packages:
@@ -492,6 +500,35 @@ packages:
       playwright-core: 1.23.4
     dev: true
 
+  /@rollup/plugin-typescript/8.3.3_55kiftncucr43pz4hskma6yi2q:
+    resolution: {integrity: sha512-55L9SyiYu3r/JtqdjhwcwaECXP7JeJ9h1Sg1VWRJKIutla2MdZQodTgcCNybXLMCnqpNLEhS2vGENww98L1npg==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.0
+      resolve: 1.22.1
+      rollup: 2.77.0
+      typescript: 4.7.4
+    dev: true
+
+  /@rollup/pluginutils/3.1.0_rollup@2.77.0:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 2.77.0
+    dev: true
+
   /@sinonjs/commons/1.8.3:
     resolution: {integrity: sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==}
     dependencies:
@@ -535,6 +572,10 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
     optional: true
+
+  /@types/estree/0.0.39:
+    resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
+    dev: true
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
@@ -1161,6 +1202,22 @@ packages:
   /concat-map/0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /concurrently/7.2.2:
+    resolution: {integrity: sha512-DcQkI0ruil5BA/g7Xy3EWySGrFJovF5RYAYxwGvv9Jf9q9B1v3jPFP2tl6axExNf1qgF30kjoNYrangZ0ey4Aw==}
+    engines: {node: ^12.20.0 || ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.28.0
+      lodash: 4.17.21
+      rxjs: 7.5.6
+      shell-quote: 1.7.3
+      spawn-command: 0.0.2-1
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.5.1
+    dev: true
+
   /conventional-commit-types/3.0.0:
     resolution: {integrity: sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==}
     dev: true
@@ -1277,6 +1334,11 @@ packages:
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
+    dev: true
+
+  /date-fns/2.28.0:
+    resolution: {integrity: sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==}
+    engines: {node: '>=0.11'}
     dev: true
 
   /debug/3.2.7_supports-color@5.5.0:
@@ -1822,6 +1884,10 @@ packages:
   /estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+    dev: true
+
+  /estree-walker/1.0.1:
+    resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
     dev: true
 
   /esutils/2.0.3:
@@ -2888,6 +2954,13 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /magic-string/0.26.2:
+    resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /make-dir/3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
@@ -3521,6 +3594,28 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rollup-plugin-dts/4.2.2_55kiftncucr43pz4hskma6yi2q:
+    resolution: {integrity: sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==}
+    engines: {node: '>=v12.22.11'}
+    peerDependencies:
+      rollup: ^2.55
+      typescript: ^4.1
+    dependencies:
+      magic-string: 0.26.2
+      rollup: 2.77.0
+      typescript: 4.7.4
+    optionalDependencies:
+      '@babel/code-frame': 7.18.6
+    dev: true
+
+  /rollup/2.77.0:
+    resolution: {integrity: sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -3603,6 +3698,10 @@ packages:
   /shebang-regex/3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  /shell-quote/1.7.3:
+    resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
+    dev: true
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -3689,6 +3788,14 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /sourcemap-codec/1.4.8:
+    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
+
+  /spawn-command/0.0.2-1:
+    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
     dev: true
 
   /spawndamnit/2.0.0:
@@ -3845,6 +3952,13 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
+  /supports-color/8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+    dependencies:
+      has-flag: 4.0.0
+    dev: true
+
   /supports-color/9.2.2:
     resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==}
     engines: {node: '>=12'}
@@ -3901,6 +4015,11 @@ packages:
     hasBin: true
     dependencies:
       nopt: 1.0.10
+    dev: true
+
+  /tree-kill/1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /trim-newlines/3.0.1:


### PR DESCRIPTION
Bundles the output to use rollup

By using a bundler we can get rid of these suspect `.js` imports in our typescript files

It's maybe worth checking the [esbuild-plugin](https://www.npmjs.com/package/rollup-plugin-esbuild) for rollup