### PR TITLE
pnpm create in place of pnpm init

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Start your next web application with Webstone and configure it as you go.
 
-```
-pnpm init webstone-app my-project
+```bash
+pnpm create webstone-app my-project
 ```
 
 > **Note**: Webstone requires the use of `pnpm` (https://pnpm.io). To install it, please run: `npm i -g pnpm`


### PR DESCRIPTION
pnpm init gives the following error:

```
pnpm init webstone-app webstone  
 ERR_PNPM_INIT_ARG  init command does not accept any arguments

Maybe you wanted to run "pnpm create webstone-app webstone"
```