### PR TITLE
Don't rely on the `npm_execpath` env variable to determine which package manager to use

### DIFF
--- a/.changeset/friendly-doors-rule.md
+++ b/.changeset/friendly-doors-rule.md
@@ -1,0 +1,5 @@
+---
+"@webstone/cli": minor
+---
+
+Determine the user's package manager with <pkg-manager> --version rather than relying on the `npm_execpath` env variable.

--- a/packages/cli/src/helpers.ts
+++ b/packages/cli/src/helpers.ts
@@ -1,3 +1,5 @@
+import { execSync } from "child_process";
+
 type PackageManagers = "npm" | "pnpm" | "yarn";
 
 /**
@@ -5,16 +7,16 @@ type PackageManagers = "npm" | "pnpm" | "yarn";
  * webstone/packages/create-webstone-app/src/helpers.ts
  */
 export const determinePackageManager = (): PackageManagers => {
-  if (process.env.npm_execpath?.endsWith("npm-cli.js")) {
-    return "npm";
-  } else if (process.env.npm_execpath?.endsWith("pnpm.cjs")) {
-    return "pnpm";
-  } else if (process.env.npm_execpath?.endsWith("yarn.js")) {
-    return "yarn";
-  } else {
-    console.warn(
-      `Could not determine package manager based on "process.env.npm_execpath". Value for env variable: ${process.env.npm_execpath}. Using npm as a fallback. Please report this as a bug, we'd love to make it more resilient.`
-    );
-    return "npm";
-  }
+  const packageManagers: PackageManagers[] = ["pnpm", "yarn"];
+  const installedPackageManager: PackageManagers =
+    packageManagers.find((pkgManager) => {
+      try {
+        execSync(`${pkgManager} --version`);
+        return pkgManager;
+      } catch (_) {
+        // Current `pkgManager` is not installed, move on to the next.
+      }
+    }) || "npm";
+
+  return installedPackageManager;
 };

--- a/packages/create-webstone-app/src/helpers.ts
+++ b/packages/create-webstone-app/src/helpers.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { execSync } from "child_process";
 
 import { ListrTaskWrapper, ListrRenderer } from "listr2/dist/index";
 
@@ -13,21 +14,21 @@ export type WebstoneTask = ListrTaskWrapper<Ctx, typeof ListrRenderer>;
 
 /**
  * If you modify this function, also change it in
- * webstone/packages/cli/src/determine-package-manager.ts
+ * webstone/packages/cli/src/helpers.ts
  */
 export const determinePackageManager = (): PackageManagers => {
-  if (process.env.npm_execpath?.endsWith("npm-cli.js")) {
-    return "npm";
-  } else if (process.env.npm_execpath?.endsWith("pnpm.cjs")) {
-    return "pnpm";
-  } else if (process.env.npm_execpath?.endsWith("yarn.js")) {
-    return "yarn";
-  } else {
-    console.warn(
-      `Could not determine package manager based on "process.env.npm_execpath". Value for env variable: ${process.env.npm_execpath}. Using npm as a fallback. Please report this as a bug, we'd love to make it more resilient.`
-    );
-    return "npm";
-  }
+  const packageManagers: PackageManagers[] = ["pnpm", "yarn"];
+  const installedPackageManager: PackageManagers =
+    packageManagers.find((pkgManager) => {
+      try {
+        execSync(`${pkgManager} --version`);
+        return pkgManager;
+      } catch (_) {
+        // Current `pkgManager` is not installed, move on to the next.
+      }
+    }) || "npm";
+
+  return installedPackageManager;
 };
 
 export const getAppName = (appDir: string) => {


### PR DESCRIPTION
The `npm_execpath` env variable isn't set if you install the package manager in a way other than `npm i -g [yarn|pnpm]`.

This PR just checks if `pnpm --version` or `yarn --version` successfully runs. If so, it picks whichever command didn't fail. If both commands fail, we fall back to NPM.